### PR TITLE
Add PaGMO library example to the main CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,4 +113,7 @@ add_subdirectory( "${PROJECTROOT}/tudatExampleApplications/satellitePropagatorEx
 if(USE_CSPICE AND USE_JSONCPP)
   add_subdirectory( "${PROJECTROOT}/tudatExampleApplications/libraryExamples/SpiceAndJSON/")
 endif()
+if(USE_PAGMO)
+  add_subdirectory( "${PROJECTROOT}/tudatExampleApplications/libraryExamples/PaGMOEx/")
+endif()
 add_subdirectory( "${PROJECTROOT}/tudatExampleApplications/templateApplication/TemplateApplication")


### PR DESCRIPTION
Accompanying tB fix for https://github.com/Tudat/tudatExampleApplications/pull/4
