### PR TITLE
Force static boost libraries when using add_boost.cmake.

### DIFF
--- a/external/CMake/add_boost.cmake
+++ b/external/CMake/add_boost.cmake
@@ -81,6 +81,10 @@ set(BoostCacheDir   "${BOOST_INCLUDEDIR}/build")
 file(MAKE_DIRECTORY "${BOOST_INCLUDEDIR}")
 file(MAKE_DIRECTORY "${BoostCacheDir}")
 
+# Force using static libraries as the build libraries are not installed to the system
+# or the libs dir added to the path.
+set(Boost_USE_STATIC_LIBS ON)
+
 #
 # Check if local Boost is not already present
 #


### PR DESCRIPTION
Recently a number of issues regarding boost have popped up:
https://github.com/Tudat/tudat/issues/161
https://github.com/Tudat/tudat/issues/179

In these builds CMake decides to link to the dynamic versions of the boost libraries. If these are provided by the add_boost.cmake they are not installed to system, nor is boost/stage/lib added to the path (for good reasons). The problem that follows however is that executables do build, but fail to execute. In our current set-up we (unfortunately) can't use dynamic libraries.

A flag to force FindBoost to look for static versions of the libraries has been added to the add_boost.cmake. This option should trickle down into any subprojects of tudatBundle. Previously this solution was tested by selective users facing this problem. 