### PR TITLE
Prevent problem with Boost inclusion in some contexts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,14 +57,6 @@ endif()
 # Pick a boost version
 set(BoostVersion 1.64.0)
 set(BoostSHA1 51421ef259a4530edea0fbfc448460fcc5c64edb)
-#set(BoostVersion 1.60.0)
-#set(BoostSHA1 7f56ab507d3258610391b47fef6b11635861175a)
-# set(BoostVersion 1.57.0)
-# set(BoostSHA1 e151557ae47afd1b43dc3fac46f8b04a8fe51c12)
-# set(BoostVersion 1.53.0)
-# set(BoostSHA1 e6dd1b62ceed0a51add3dda6f3fc3ce0f636a7f3)
-# set(BoostVersion 1.48.0)
-# set(BoostSHA1 27aced5086e96c6f7b2b684bda2bd515e115da35)
 
 # Minimum boost version required for PagMO2 is 1.55
 if(USE_PAGMO)
@@ -83,6 +75,10 @@ if(USE_PAGMO)
   unset(boost_version)
   unset(boost_release)
 endif()
+
+# This prevents problems with find_package() if multiple versions of
+# Boost already exist on the system
+set(Boost_NO_BOOST_CMAKE ON)
 
 # Build boost
 include(add_boost)

--- a/external/CMake/add_boost.cmake
+++ b/external/CMake/add_boost.cmake
@@ -16,7 +16,7 @@
 #        http://www.maidsafe.net/licenses
 
 #
-# Hepler function(s)
+# Helper function(s)
 #
 # Gets the path to the temp directory using the same method as Boost.Filesystem:
 # http://www.boost.org/doc/libs/release/libs/filesystem/doc/reference.html#temp_directory_path


### PR DESCRIPTION
Closes #53 

* Added magic flag that prevents problems with find_package(Boost) on systems that have `libboost-dev` installed/built
* Removed old boost versions 